### PR TITLE
Migrate PyPDF2 → pypdf (fix CVE-2023-36464, Dependabot alert #1)

### DIFF
--- a/DocSkills/Read/scripts/run.py
+++ b/DocSkills/Read/scripts/run.py
@@ -6,7 +6,7 @@ images. Also provides figure metadata catalogs and sub-image pixel fetch —
 the unified content tool for pages, images, and figures.
 
 Text modes:
-  * ``text`` (default)   — raw text via PyPDF2
+  * ``text`` (default)   — raw text via pypdf
   * ``markdown``         — MinerU per-page markdown (auto when --markdown-dir
                            supplied AND that doc has markdown available)
 

--- a/DocSkills/_common/pdf_text.py
+++ b/DocSkills/_common/pdf_text.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import re
 
-import PyPDF2
+import pypdf
 
 
 def get_pages_text(
@@ -25,7 +25,7 @@ def get_pages_text(
     """
     found: dict[int, str] = {}
     missing: list[int] = []
-    reader = PyPDF2.PdfReader(pdf_path)
+    reader = pypdf.PdfReader(pdf_path)
     n_pages = len(reader.pages)
     for p in page_nums:
         try:
@@ -49,4 +49,4 @@ def has_real_text(pages: dict[int, str]) -> bool:
 
 
 def page_count(pdf_path: str) -> int:
-    return len(PyPDF2.PdfReader(pdf_path).pages)
+    return len(pypdf.PdfReader(pdf_path).pages)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,10 @@ dependencies = [
     "tqdm>=4.66",
 
     # ── PDF I/O (Read skill, build-md, build-tree shared helpers) ──
-    "PyPDF2>=3.0",
+    "pypdf>=5.0",
     "pymupdf>=1.23",
     "pillow>=12.3.0",
-    "pycryptodome>=3.20",   # PyPDF2 dep for encrypted PDFs
+    "pycryptodome>=3.20",   # optional crypto backend for encrypted PDFs
 
     # ── PDF → markdown / figures (build-md, Docling backend) ──
     # Heron layout + TableFormer + EasyOCR; CPU-only by default,

--- a/tests/test_unified_read.py
+++ b/tests/test_unified_read.py
@@ -22,12 +22,12 @@ _MINI_DOC = _FIXTURE_DIR / "mini_doc"
 
 
 def _find_python() -> str:
-    """Find a Python with PyPDF2 + PIL available."""
+    """Find a Python with pypdf + PIL available."""
     # Try conda pageindex env first
     try:
         r = subprocess.run(
             ["conda", "run", "-n", "pageindex", "python", "-c",
-             "import PyPDF2; import PIL; print('ok')"],
+             "import pypdf; import PIL; print('ok')"],
             capture_output=True, text=True, timeout=15,
         )
         if r.returncode == 0 and "ok" in r.stdout:
@@ -37,7 +37,7 @@ def _find_python() -> str:
     # Try sys.executable
     try:
         r = subprocess.run(
-            [sys.executable, "-c", "import PyPDF2; import PIL; print('ok')"],
+            [sys.executable, "-c", "import pypdf; import PIL; print('ok')"],
             capture_output=True, text=True, timeout=10,
         )
         if r.returncode == 0 and "ok" in r.stdout:
@@ -61,7 +61,7 @@ def _run_read(extra_args: list[str], env_override: dict[str, str] | None = None)
     elif _PYTHON_MODE == "sys":
         cmd = [sys.executable, str(_READ_SCRIPT)] + extra_args
     else:
-        pytest.skip("No Python with PyPDF2+PIL found")
+        pytest.skip("No Python with pypdf+PIL found")
 
     r = subprocess.run(cmd, capture_output=True, text=True, timeout=60, env=env)
     assert r.returncode in (0, 2), f"Read CLI failed: {r.stderr}"
@@ -75,7 +75,7 @@ needs_fixtures = pytest.mark.skipif(
 
 needs_python = pytest.mark.skipif(
     not _PYTHON_MODE,
-    reason="No Python environment with PyPDF2+PIL available",
+    reason="No Python environment with pypdf+PIL available",
 )
 
 
@@ -139,7 +139,7 @@ def test_text_mode_returns_empty_figure_meta():
     import tempfile
     # Create minimal PDF via the available Python
     pdf_script = (
-        "import sys; from PyPDF2 import PdfWriter; "
+        "import sys; from pypdf import PdfWriter; "
         "w = PdfWriter(); w.add_blank_page(72,72); "
         "w.write(open(sys.argv[1], 'wb'))"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -462,7 +462,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pycryptodome" },
     { name = "pymupdf" },
-    { name = "pypdf2" },
+    { name = "pypdf" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "tiktoken" },
@@ -487,7 +487,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pycryptodome", specifier = ">=3.20" },
     { name = "pymupdf", specifier = ">=1.23" },
-    { name = "pypdf2", specifier = ">=3.0" },
+    { name = "pypdf", specifier = ">=5.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "python-dotenv", specifier = ">=1.0" },
@@ -2039,12 +2039,15 @@ wheels = [
 ]
 
 [[package]]
-name = "pypdf2"
-version = "3.0.1"
+name = "pypdf"
+version = "6.14.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/bb/18dc3062d37db6c491392007dfd1a7f524bb95886eb956569ac38a23a784/PyPDF2-3.0.1.tar.gz", hash = "sha256:a74408f69ba6271f71b9352ef4ed03dc53a31aa404d29b5d31f53bfecfee1440", size = 227419, upload-time = "2022-12-31T10:36:13.13Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/5e/c86a5643653825d3c913719e788e41386bee415c2b87b4f955432f2de6b2/pypdf2-3.0.1-py3-none-any.whl", hash = "sha256:d16e4205cfee272fbdc0568b68d82be796540b1537508cef59388f839c191928", size = 232572, upload-time = "2022-12-31T10:36:10.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
 ]
 
 [[package]]

--- a/vendor/pageindex/UPSTREAM.md
+++ b/vendor/pageindex/UPSTREAM.md
@@ -25,7 +25,10 @@ original copyright notice intact.
 
 ## What was modified
 
-Nothing. The Python source is copied verbatim. The directory contains:
+One local security patch: `PyPDF2` → `pypdf` (its drop-in successor) throughout
+`utils.py`, to drop the deprecated PyPDF2 dependency (CVE-2023-36464 /
+GHSA-4vvm-4w3v-6mr8 — possible infinite loop on crafted PDFs). Otherwise the
+Python source is copied verbatim. The directory contains:
 
 - `__init__.py` — re-exports `page_index_main`, `config`, `utils.*`
 - `page_index.py` — text-mode tree construction
@@ -45,7 +48,7 @@ is a reasonable trade.
 
 PageIndex's `requirements.txt` lists:
 
-- `openai`, `pymupdf`, `PyPDF2`, `python-dotenv`, `tiktoken`, `pyyaml`,
+- `openai`, `pymupdf`, `pypdf`, `python-dotenv`, `tiktoken`, `pyyaml`,
   `azure-identity`, `pycryptodome`
 
 All of these are already pinned in DocAtlas's `pyproject.toml`, so

--- a/vendor/pageindex/utils.py
+++ b/vendor/pageindex/utils.py
@@ -7,7 +7,7 @@ import base64 as _base64
 from datetime import datetime
 import time
 import json
-import PyPDF2
+import pypdf
 import copy
 import asyncio
 import pymupdf
@@ -529,7 +529,7 @@ def get_last_node(structure):
 
 
 def extract_text_from_pdf(pdf_path):
-    pdf_reader = PyPDF2.PdfReader(pdf_path)
+    pdf_reader = pypdf.PdfReader(pdf_path)
     ###return text not list 
     text=""
     for page_num in range(len(pdf_reader.pages)):
@@ -538,13 +538,13 @@ def extract_text_from_pdf(pdf_path):
     return text
 
 def get_pdf_title(pdf_path):
-    pdf_reader = PyPDF2.PdfReader(pdf_path)
+    pdf_reader = pypdf.PdfReader(pdf_path)
     meta = pdf_reader.metadata
     title = meta.title if meta and meta.title else 'Untitled'
     return title
 
 def get_text_of_pages(pdf_path, start_page, end_page, tag=True):
-    pdf_reader = PyPDF2.PdfReader(pdf_path)
+    pdf_reader = pypdf.PdfReader(pdf_path)
     text = ""
     for page_num in range(start_page-1, end_page):
         page = pdf_reader.pages[page_num]
@@ -583,7 +583,7 @@ def get_pdf_name(pdf_path):
     if isinstance(pdf_path, str):
         pdf_name = os.path.basename(pdf_path)
     elif isinstance(pdf_path, BytesIO):
-        pdf_reader = PyPDF2.PdfReader(pdf_path)
+        pdf_reader = pypdf.PdfReader(pdf_path)
         meta = pdf_reader.metadata
         pdf_name = meta.title if meta and meta.title else 'Untitled'
         pdf_name = sanitize_filename(pdf_name)
@@ -694,10 +694,10 @@ def add_preface_if_needed(data):
 
 
 
-def get_page_tokens(pdf_path, model="gpt-4o-2024-11-20", pdf_parser="PyPDF2"):
+def get_page_tokens(pdf_path, model="gpt-4o-2024-11-20", pdf_parser="pypdf"):
     enc = _get_tiktoken_encoding(model)
-    if pdf_parser == "PyPDF2":
-        pdf_reader = PyPDF2.PdfReader(pdf_path)
+    if pdf_parser == "pypdf":
+        pdf_reader = pypdf.PdfReader(pdf_path)
         page_list = []
         for page_num in range(len(pdf_reader.pages)):
             page = pdf_reader.pages[page_num]
@@ -839,7 +839,7 @@ def get_text_of_pdf_pages_with_labels(pdf_pages, start_page, end_page):
     return text
 
 def get_number_of_pages(pdf_path):
-    pdf_reader = PyPDF2.PdfReader(pdf_path)
+    pdf_reader = pypdf.PdfReader(pdf_path)
     num = len(pdf_reader.pages)
     return num
 


### PR DESCRIPTION
## What
Replaces the deprecated **PyPDF2** dependency with **pypdf**, its maintained drop-in successor (identical `PdfReader` / `.pages` / `.extract_text()` API).

## Why
PyPDF2 is deprecated and has **no patched release** for **CVE-2023-36464** / **GHSA-4vvm-4w3v-6mr8** — a crafted PDF can trigger an infinite loop during text extraction, which is exactly the `Read` skill's code path. Dependabot can't auto-fix this (there's no version to bump to), so the fix is this package migration.

## Changes
- `pyproject.toml`: `PyPDF2>=3.0` → `pypdf>=5.0`
- `uv.lock`: the only change is `pypdf2 3.0.1` removed / `pypdf 6.14.2` added
- `DocSkills/_common/pdf_text.py`, `tests/test_unified_read.py`: `PyPDF2.PdfReader` → `pypdf.PdfReader`
- **`vendor/pageindex/utils.py`**: the vendored PageIndex also imports PyPDF2, so it's migrated too (drop-in) — otherwise `build-tree` would break at import once PyPDF2 is removed. Documented in `vendor/pageindex/UPSTREAM.md`.

18/18 tests pass locally. Closes the PyPDF2 Dependabot alert once merged.
