### PR TITLE
docs: polish README (highlights, result deltas, richer layout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,91 +8,102 @@
   <img src="assets/framework.png" alt="DocAtlas framework" width="100%">
 </p>
 
-## Overview
+## 🧭 What is DocAtlas?
 
-Long-document understanding requires finding and combining evidence scattered across
-many pages, layouts, tables, figures, and charts. Retrieval-augmented systems select
-evidence from a **static** index before generation; recent agentic systems add
-multi-turn tool use but usually leave the document representation frozen and specify
-behavior through prompts on top of proprietary backbones.
+> **DocAtlas turns a long document into _mutable state_ the model updates while it works.**
+> Instead of retrieving from a frozen index, the agent searches a **living document tree**,
+> reads pages selectively, writes source-grounded notes, and reviews them — and every action
+> reshapes what later steps can find. The **same** environment powers strong inference-time
+> VLMs **and** end-to-end RL for compact agents.
 
-**DocAtlas treats long-document understanding as a _mutable-state information-seeking
-process_.** It is a *mutable document harness*: an external environment that decides
-what document information is searched, read, stored, reviewed, and shown to the model
-at each step. Given a document and a question, the harness exposes four tools —
-**Search, Read, Note, Review** — and maintains a hierarchical document tree and a
-structured note store that **the agent's own actions update as it works**. A later
-`Search` therefore depends on what the agent has already read and recorded, so
-retrieval becomes part of a closed decision loop rather than a fixed preprocessing step.
+### ✨ Highlights
 
-The *same* harness serves two regimes:
+- 🌲 **Self-improving retrieval** — a document tree the agent *enriches as it reads*, so later search sees accumulated evidence (not a frozen index).
+- 🎯 **Decoupled Search + Read** — high-recall *find* → selective, multimodal *consume*.
+- 🧠 **Active working memory** — source-grounded Notes + on-demand Review under a fixed context budget.
+- 🖼️ **Real multimodal reading** — full-page layout image + MinerU markdown + figure/chart crops.
+- 🔁 **One environment, two regimes** — inference *and* end-to-end RL (tool use is *learned*, not prompt-scripted).
+- 🏆 **Beats the human expert** on MMLongBench-Doc — with big gains across 3 benchmarks.
 
-- **Inference-time** use with strong VLMs (e.g. GPT-5.4).
-- **End-to-end reinforcement learning** for compact VLM agents (e.g. Qwen3.5-4B):
-  the interaction protocol is identical at inference and during RL, so tool use can
-  be *learned* instead of hand-scripted in a prompt.
+### 🧰 The four tools
 
-> **Headline.** With **GPT-5.4**, DocAtlas reaches **71.4%** on MMLongBench-Doc, above
-> the **65.8%** human-expert reference. A **Qwen3.5-4B** trained end-to-end with RL in
-> the DocAtlas environment reaches **63.7%**, up from a **54.4%** direct-input baseline.
+|  | Tool | What it does |
+|:--:|---|---|
+| 🔎 | **Search** | Navigate the document tree → propose relevant regions (high recall) |
+| 📖 | **Read** | Consume selected pages: layout image + markdown + figure/chart crops |
+| 📝 | **Note** | Record source-grounded findings; write them back into the tree |
+| 🔁 | **Review** | Recall the relevant prior notes on demand |
 
-## Key results
+## 📊 Results
 
-Main results across three long-document benchmarks (see the paper for the full table
-with per-evidence-source breakdowns and all baselines):
+> 🏆 **GPT-5.4 + DocAtlas → 71.4%** on MMLongBench-Doc — **+9.0** over direct input, **+5.6 above the 65.8% human expert**.
+> 🚀 **RL-trained Qwen3.5-4B → 63.7%** — a compact **4B** agent, **+9.3** over its 54.4% direct baseline.
+> 📈 Biggest single jump: **FinRAGBench-V +20.5** (GPT-5.4).
 
-| Backbone | Setting | MMLongBench-Doc (Acc) | FinRAGBench-V (LasJ) | LongDocURL (LasJ) |
+Results across three long-document benchmarks (small ▲ = **gain over the same backbone's direct-input row**):
+
+| Backbone | Setting | MMLongBench-Doc | FinRAGBench-V | LongDocURL |
 |---|---|:---:|:---:|:---:|
 | GPT-5.4 | direct input | 62.4 | 55.1 | 66.9 |
-| GPT-5.4 | **+ DocAtlas** | **71.4** | **75.6** | **78.8** |
+| **GPT-5.4** | **+ DocAtlas** | **71.4** 🏆 <sub>▲9.0</sub> | **75.6** <sub>▲20.5</sub> | **78.8** <sub>▲11.9</sub> |
 | GPT-5.2 | + DocAtlas | 70.6 | 75.2 | 77.5 |
 | Qwen3.5-4B | direct input | 54.4 | 52.8 | 52.4 |
-| Qwen3.5-4B | + DocAtlas | 61.0 | 67.9 | 72.5 |
-| Qwen3.5-4B | + DocAtlas + RL | 63.7 | 71.7 | — |
+| Qwen3.5-4B | + DocAtlas | 61.0 <sub>▲6.6</sub> | 67.9 <sub>▲15.1</sub> | 72.5 <sub>▲20.1</sub> |
+| Qwen3.5-4B | **+ DocAtlas + RL** | **63.7** <sub>▲9.3</sub> | **71.7** <sub>▲18.9</sub> | — |
 | Qwen3.5-9B | + DocAtlas + RL | 64.4 | 72.6 | — |
-| *Human expert* | *reference* | *65.8* | — | — |
+| _Human expert_ | _reference_ | _65.8_ | — | — |
 
-*MMLongBench-Doc is reported as overall accuracy; FinRAGBench-V and LongDocURL as
-LLM-as-judge (LasJ) scores. RL rows omit LongDocURL because it is used to construct the
-RL training data.*
+<sub>MMLongBench-Doc = overall accuracy; FinRAGBench-V / LongDocURL = LLM-as-judge. RL rows omit LongDocURL (it is used to build the RL data). ▲ compares each DocAtlas row to the same backbone's direct-input row.</sub>
 
-**Ablations** (MMLongBench-Doc, GPT-5.4, full system = 71.4) confirm every component
-contributes: removing full-page layout images drops accuracy to 65.7, cropped
-sub-images to 67.2, decoupled `Read` to 67.2, and each active-memory component
-(`Note` / `Review` / evidence field / tree annotation) to 67.8–68.3. An auxiliary-model
-study shows the frozen GPT-5.4 used inside `Search`/`Review` is *not* required: an
-open-weight (Qwen3.5-35B-A3B) auxiliary loses only 0.3–0.4 points, and a fully
-self-hosted auxiliary stays within ~2 points.
+<details>
+<summary><b>🔬 Ablations &amp; auxiliary-model robustness</b></summary>
 
-## How it works
+<br>
+
+Every component earns its place (MMLongBench-Doc, GPT-5.4, full = **71.4**):
+
+| Remove… | Acc |
+|---|:---:|
+| full-page layout images | 65.7 |
+| cropped sub-images | 67.2 |
+| decoupled `Read` (consume Search hits directly) | 67.2 |
+| `Note` / `Review` / evidence field / tree annotation | 67.8–68.3 |
+| **nothing (full DocAtlas)** | **71.4** |
+
+The frozen GPT-5.4 used inside `Search`/`Review` is **not** required: an open-weight
+(Qwen3.5-35B-A3B) auxiliary loses only **0.3–0.4** points, and a fully self-hosted
+auxiliary stays within **~2** points.
+
+</details>
+
+## 🔍 How it works
 
 DocAtlas is built on three design principles (see the figure above and
 [`ARCHITECTURE.md`](./ARCHITECTURE.md) for the implementation):
 
-1. **Self-improving retrieval.** Each document is organized offline into a hierarchical
-   **tree** (question-agnostic, built by a VLM using structured markdown + visual parsing
-   of figures/tables/charts). `Search` navigates this tree; when the agent records
-   findings via `Note`, those page-grounded findings are written *back* into the finest
-   covering node, so later `Search` calls see accumulated evidence alongside the original
-   summaries.
-2. **Selective evidence access.** `Search` and `Read` are **decoupled**: `Search`
-   proposes candidate regions (high recall), while `Read` gives the agent explicit
-   control over which pages to actually consume — and in which modality. Each `Read`
-   returns a full-page layout image, structured markdown (extracted by
-   [MinerU](https://github.com/opendatalab/MinerU)), and cropped figure/chart sub-images.
-3. **Active working memory.** `Note` records structured, source-attributed findings
-   (`found`, `evidence`, `plan`) and can archive bulky read observations in place;
-   `Review` selectively recalls prior notes. This lets the agent reason across many steps
-   under a fixed context budget.
+1. **🌲 Self-improving retrieval.** Each document is organized offline into a hierarchical
+   **tree** (question-agnostic, built by a VLM using structured markdown + visual parsing of
+   figures/tables/charts). `Search` navigates this tree; when the agent records findings via
+   `Note`, those page-grounded findings are written *back* into the finest covering node, so
+   later `Search` calls see accumulated evidence alongside the original summaries.
+2. **🎯 Selective evidence access.** `Search` and `Read` are **decoupled**: `Search` proposes
+   candidate regions (high recall), while `Read` gives the agent explicit control over which
+   pages to actually consume — and in which modality. Each `Read` returns a full-page layout
+   image, structured markdown (extracted by [MinerU](https://github.com/opendatalab/MinerU)),
+   and cropped figure/chart sub-images.
+3. **🧠 Active working memory.** `Note` records structured, source-attributed findings
+   (`found`, `evidence`, `plan`) and can archive bulky read observations in place; `Review`
+   selectively recalls prior notes. This lets the agent reason across many steps under a fixed
+   context budget.
 
 Each episode is a trajectory of tool calls over a mutable environment state
-`S = (document, tree, note store, explored pages)`. The four tools have a fixed action
-space but **no fixed execution order** — the agent may interleave search, reading, and
-memory operations freely. Because this is a sequential decision problem, the identical
-environment supports outcome-based RL (GRPO with DAPO-style asymmetric clipping; reward
-computed from the final boxed answer with the LongDocURL type-aware score).
+`S = (document, tree, note store, explored pages)`. The four tools have a fixed action space
+but **no fixed execution order** — the agent may interleave search, reading, and memory
+operations freely. Because this is a sequential decision problem, the identical environment
+supports outcome-based RL (GRPO with DAPO-style asymmetric clipping; reward computed from the
+final boxed answer with the LongDocURL type-aware score).
 
-## Repository layout
+## 📂 Repository layout
 
 - `DocSkills/` — portable SKILLs (`SKILL.md` + `tool.json` + CLI scripts) for
   **Search / Read / Note / Review**. Runtime-agnostic: consumable by this harness or any
@@ -106,7 +117,7 @@ computed from the final boxed answer with the LongDocURL type-aware score).
 - `evals/` — per-skill regression evals.
 - `vendor/pageindex/` — vendored [PageIndex](https://github.com/VectifyAI/PageIndex) (MIT).
 
-## Installation
+## ⚙️ Installation
 
 DocAtlas uses [`uv`](https://github.com/astral-sh/uv) for its venv and lockfile. From the
 repo root:
@@ -127,29 +138,34 @@ After `uv sync` the `harness` console script is available:
 ```
 
 Copy `.env.example` to `.env` and fill in your **Azure OpenAI** endpoint + deployment.
-Auth defaults to `AzureCliCredential` (run `az login` once) or set
-`AZURE_OPENAI_API_KEY`. All model/deployment names are **required** (no baked-in
-defaults) — set `AZURE_OPENAI_DEPLOYMENT` in `.env` and pass `--model` to the scorers.
+Auth defaults to `AzureCliCredential` (run `az login` once) or set `AZURE_OPENAI_API_KEY`.
+All model/deployment names are **required** (no baked-in defaults) — set
+`AZURE_OPENAI_DEPLOYMENT` in `.env` and pass `--model` to the scorers.
 
-If you drive the harness from a shell without the venv activated, point at it explicitly:
+<details>
+<summary>Driving from a shell without the venv activated / heavy-dependency notes</summary>
+
+<br>
+
+Point at the venv explicitly:
 
 ```bash
 export HARNESS_DRIVER_PYTHON=/path/to/DocAtlas/.venv/bin/python   # scripts + demos
 export HARNESS_SKILL_PYTHON=/path/to/DocAtlas/.venv/bin/python    # SKILL subprocesses
 ```
 
-### Notes on heavy dependencies
-
-- **Docling** (`build-md`): pulls layout + table + OCR models from HuggingFace on first
-  run (~2 GB to `~/.cache/huggingface/`), then runs offline. `uv sync --extra gpu` adds a
-  CUDA torch constraint (~3–5× faster `build-md`).
+- **Docling** (`build-md`): pulls layout + table + OCR models from HuggingFace on first run
+  (~2 GB to `~/.cache/huggingface/`), then runs offline. `uv sync --extra gpu` adds a CUDA
+  torch constraint (~3–5× faster `build-md`).
 - **PageIndex** (`build-tree`): **vendored** at `vendor/pageindex/` (MIT; see
   `vendor/pageindex/UPSTREAM.md`). No extra install step. The loader prefers any importable
   `pageindex` over the vendored copy if you pin upstream yourself.
 - **Skill aux LLM**: SKILLs that call an LLM (`Search`, `Review`) read
   `HARNESS_AUX_LLM_{ENDPOINT,API_VERSION,MODEL,API_KEY}` or fall back to `AZURE_OPENAI_*`.
 
-## Quick start
+</details>
+
+## 🚀 Quick start
 
 Run the end-to-end demo on the bundled, fully self-authored sample PDF:
 
@@ -177,7 +193,7 @@ bash scripts/demo_end_to_end.sh --chat-only     # reuse cached artifacts, chat o
 Outputs are cached under `outputs/demo/<doc_stem>/` so re-runs short-circuit completed
 stages. The chat stage runs the 4-skill loop with live plain-text progress.
 
-## Preprocessing
+## 🔧 Preprocessing
 
 ### `harness build-tree` — PageIndex tree construction
 
@@ -193,16 +209,20 @@ python -m harness build-tree \
 
 ### `harness build-md` — per-page Markdown extraction (Docling)
 
-Turns a directory of PDFs into the per-page markdown + figures layout that `Read`
-consumes via `--markdown-dir`, backed by [Docling](https://github.com/docling-project/docling).
+Turns a directory of PDFs into the per-page markdown + figures layout that `Read` consumes
+via `--markdown-dir`, backed by [Docling](https://github.com/docling-project/docling).
 
-> **⚠️ Reproducing the paper?** The reported numbers were produced with **MinerU 2.5**,
-> *not* Docling. This bundled `build-md` (Docling) is a **low-resource convenience path**
-> so the pipeline runs end-to-end on a CPU-only box; its markdown is lower-fidelity on
-> dense tables/formulas and **will not match the reported results**. To reproduce, extract
-> markdown with [MinerU 2.5](https://github.com/opendatalab/MinerU) and point
-> `--markdown-dir` at its output. Both backends emit the **same on-disk layout**, so
-> nothing else on the inference path changes.
+> **⚠️ Reproducing the paper?** The reported numbers were produced with **MinerU 2.5**, *not*
+> Docling. This bundled `build-md` (Docling) is a **low-resource convenience path** so the
+> pipeline runs end-to-end on a CPU-only box; its markdown is lower-fidelity on dense
+> tables/formulas and **will not match the reported results**. To reproduce, extract markdown
+> with [MinerU 2.5](https://github.com/opendatalab/MinerU) and point `--markdown-dir` at its
+> output. Both backends emit the **same on-disk layout**, so nothing else changes.
+
+<details>
+<summary>On-disk layout &amp; more <code>build-md</code> examples</summary>
+
+<br>
 
 The shared on-disk layout (consumed by `DocSkills/_common/markdown_reader.py`):
 
@@ -228,7 +248,9 @@ python -m harness build-md --pdf-dir data/MMLongBench/documents \
 
 `build-md` is idempotent (skips docs already extracted unless `--force`).
 
-## Multi-doc / cross-doc QA
+</details>
+
+## 🔀 Multi-doc / cross-doc QA
 
 For questions that span multiple PDFs ("compare the EN and FR editions", "across the
 2018–2024 annual reports…"), the harness merges per-doc trees into one **series tree** and
@@ -258,17 +280,15 @@ Both tree builders accept a `--manifest <file.json>` (a list of
 `{pdf | tree, title?, summary?, markdown_dir?}` objects) for per-doc overrides.
 `scripts/demo_end_to_end_multi.sh` chains the whole multi-doc pipeline on a pair of PDFs.
 
-## Reproducing the paper
+## 🧪 Reproducing the paper
 
 The benchmark corpora are **not redistributed** with this repo. Obtain them from their
 sources and point the harness at them (again: use **MinerU 2.5** for markdown to match the
 reported numbers).
 
 A tiny, fully self-authored `data/sample_pdfs/sample_report.pdf` (regenerate with
-`python data/sample_pdfs/make_sample.py`) ships so the demos and `Read` evals run without
-any external corpus.
-
-### Evaluation & scoring
+`python data/sample_pdfs/make_sample.py`) ships so the demos and `Read` evals run without any
+external corpus.
 
 ```bash
 # Run the agent loop over MMLongBench-Doc with the paper's best config
@@ -278,11 +298,11 @@ bash scripts/run_eval.sh --limit 20 --n-jobs 4
 python scoring/score_mmlongbench_hybrid.py -i outputs/<run>.json --model <your-deployment>
 ```
 
-`scripts/run_eval.sh` encodes the paper's best inference config: 4 skills,
-`--detail high`, `--vision-zoom 1.0`, high reasoning effort, `--max-turns 50`, memory off,
-tree-annotation on (enabled automatically by the eval runner).
+`scripts/run_eval.sh` encodes the paper's best inference config: 4 skills, `--detail high`,
+`--vision-zoom 1.0`, high reasoning effort, `--max-turns 50`, memory off, tree-annotation on
+(enabled automatically by the eval runner).
 
-## Citation
+## 📌 Citation
 
 If you use DocAtlas in your research, please cite:
 
@@ -297,12 +317,12 @@ If you use DocAtlas in your research, please cite:
 }
 ```
 
-## Acknowledgements
+## 🙏 Acknowledgements
 
-DocAtlas builds on excellent open-source work: the hierarchical tree index is inspired by
-and vendors [PageIndex](https://github.com/VectifyAI/PageIndex); per-page markdown uses
+DocAtlas builds on excellent open-source work: the hierarchical tree index is inspired by and
+vendors [PageIndex](https://github.com/VectifyAI/PageIndex); per-page markdown uses
 [MinerU](https://github.com/opendatalab/MinerU) (paper setup) or
-[Docling](https://github.com/docling-project/docling) (bundled fallback); and RL training
-uses [verl](https://github.com/volcengine/verl) with [vLLM](https://github.com/vllm-project/vllm).
+[Docling](https://github.com/docling-project/docling) (bundled fallback); and RL training uses
+[verl](https://github.com/volcengine/verl) with [vLLM](https://github.com/vllm-project/vllm).
 We evaluate on MMLongBench-Doc, FinRAGBench-V, and LongDocURL, and thank their authors for
 releasing these benchmarks.


### PR DESCRIPTION
## What
Polishes the README for readability and impact — **content only, no code changes**.

## Changes
- 🧭 Compressed intro → a one-line thesis + short TL;DR + a scannable **Highlights** block + a **four-tools** table.
- 📊 **Results now surface the gains**: `▲` deltas vs each backbone's direct-input row (GPT-5.4 **+9.0** over direct / **+5.6** over the 65.8% human expert; FinRAGBench-V **+20.5**), plus an at-a-glance callout.
- ✨ Emoji section headers for visual rhythm.
- 🔬 Verbose blocks (extra install notes, on-disk layout, ablation detail) folded into `<details>` so the page scans faster.

No functional changes; `Repository layout` and all paths unchanged.
